### PR TITLE
Remove `#![feature(track_caller)]` by upgrading `topo`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ typemap = "0.3.3"
 # atomic_hooks_macros = "0.1.3"
 atomic_hooks_macros = {path = "./macro"}
 # seed = "0.7.0"
-topo = "=0.9.4"
+topo = "0.12.0"
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -22,7 +22,7 @@ pub fn do_once<F: FnMut() -> ()>(mut func: F) -> StateAccess<bool> {
 
 
 #[derive(Clone,Copy,Debug,PartialEq,Hash,Eq)]
-pub struct Local( topo::Id );
+pub struct Local( topo::CallId );
 
 impl std::fmt::Display for Local {
 
@@ -34,7 +34,7 @@ impl std::fmt::Display for Local {
 impl Local{
     #[topo::nested]
     pub fn new() -> Local{
-        Local( topo::Id::current())
+        Local( topo::CallId::current())
     }
 }
 

--- a/src/hooks_state_functions.rs
+++ b/src/hooks_state_functions.rs
@@ -47,7 +47,7 @@ pub fn use_state<T: 'static, F: FnOnce() -> T>(data_fn: F) -> StateAccess<T> {
 ///
 ///
 pub fn use_state_current<T: 'static, F: FnOnce() -> T>(data_fn: F) -> StateAccess<T> {
-    let id = topo::Id::current();
+    let id = topo::CallId::current();
     let ctx = get_state_slotted_key_struct_if_in_context();
 
     let id = TopoKey {
@@ -66,7 +66,7 @@ pub fn use_state_current<T: 'static, F: FnOnce() -> T>(data_fn: F) -> StateAcces
 pub fn new_state<T: 'static, F: FnOnce() -> T>(data_fn: F) -> StateAccess<T> {
     let count = use_state(|| 0);
     count.update(|c| *c += 1);
-    topo::call_in_slot(count.get(), || use_state_current(data_fn))
+    topo::call_in_slot(&count.get(), || use_state_current(data_fn))
 }
 
 /// Sets the state of type T keyed to the given TopoId

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(track_caller)]
 pub use atomic_hooks_macros::{atom, reaction};
 // storage
 mod store;

--- a/src/store.rs
+++ b/src/store.rs
@@ -43,7 +43,7 @@ pub struct SlottedKey
 pub struct TopoKey
 {
     pub ctx: Option<SlottedKey>,
-    pub id: topo::Id,
+    pub id: topo::CallId,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
`track_caller` is stable in both beta and nightly now. This adds support for the beta compiler.